### PR TITLE
Fixing an infinite loop when there is no newline at the end of the file.

### DIFF
--- a/genstring.py
+++ b/genstring.py
@@ -117,7 +117,10 @@ class LocalizedFile():
 
             # handle multi lines
             while len(line) > 1 and line[-2] != u';':
-                line += f.readline()
+                nextline = f.readline()
+                if not nextline:
+                    nextline = '\n'
+                line += nextline
                 i += 1
 
             logging.debug("%d %s" % (i, line.rstrip('\n')))


### PR DESCRIPTION
If Localizable.strings for some reason has no newline at the end of it, genstring.py runs into an infinite loop.
